### PR TITLE
Fixed profile icon overlapping the separator for non-VR users

### DIFF
--- a/hidename/resource/layout/steamrootdialog.layout
+++ b/hidename/resource/layout/steamrootdialog.layout
@@ -2,8 +2,6 @@
 {
 	controls
 	{
-
-			
 		"fullscreen"
 		{
 			"ControlName"		"Button"
@@ -16,10 +14,10 @@
 		{
 			"ControlName"		"Button"
 			style="VRButton"
-      command="startvr"
-     	tooltiptext="#tooltip_view_vr_start" 
+			command="startvr"
+			tooltiptext="#tooltip_view_vr_start" 
 		}
-    
+		
 		"exitvr"
 		{
 			"ControlName"		"Button"
@@ -30,23 +28,23 @@
 		
 		"New"
 		{
-		"ControlName" 	"URLLabel"
-		style="new_label"
-		"URLText"		"http://store.steampowered.com/uiupdate"
-		zpos=-2
+			"ControlName"	"URLLabel"
+			style="new_label"
+			"URLText"		"http://store.steampowered.com/uiupdate"
+			zpos=-2
 		}
 		
 		"UINavigatorPanel"
 		{
 			"ControlName"		"CUINavigatorPanel"
 			zpos=-2
-		}	
+		}
 		
 		"UIStatusPanel"
 		{
 			"ControlName"		"CUIStatusPanel"
 			zpos=-2
-		}	
+		}
 		
 		"MenuBar"
 		{
@@ -61,8 +59,8 @@
 			style="support_alert"
 			textAlignment=center
 			command="OpenSupportAlertWindow"
-		}	
-
+		}
+		
 		ParentalLockButton
 		{
 			ControlName=ToggleButton
@@ -77,7 +75,7 @@
 			ControlName=MenuButton
 			style="inbox_button"
 			textAlignment=west
-		}	
+		}
 		
 		add_game
 		{
@@ -89,20 +87,19 @@
 		frame_title
 		{
 			ControlName=Label
-	
+			
 			style="ClientTitle"
-			"textAlignment"   "west"
-			"textAlignment"   "center" [$OSX]
+			"textAlignment"		"west"
+			"textAlignment"		"center" [$OSX]
 		}
 		
 		account_url
 		{
-			"ControlName"		"MenuButton"
+			"ControlName"	"MenuButton"
 			"fieldName"		"account_url"
 			"labelText"		"#Steam_Account_Name"
 			style="AccountURLStyle"
 		}
-		
 		
 		account_balance
 		{
@@ -126,7 +123,7 @@
 			ControlName=Label
 			labelText=#Steam_Universe_Internal
 		}
-
+		
 		view_friends
 		{
 			ControlName=URLLabel
@@ -135,6 +132,7 @@
 			style="view_friends"
 			textAlignment=east
 		}
+		
 		online_friends
 		{
 			ControlName=Label
@@ -146,47 +144,45 @@
 	}
 	
 	styles
-	{    		
-			
+	{
 		AccountBalanceStyle
 		{
-		      textcolor="labeldisabled"
-		      bgcolor="none"
-		      font-family=basefont
-		      font-size=14
-		      font-weight=400
-		      font-style=regular
+			textcolor="labeldisabled"
+			bgcolor="none"
+			font-family=basefont
+			font-size=14
+			font-weight=400
+			font-style=regular
 		}
-
+		
 		AccountBalanceStyle [$OSX]
 		{
-		      textcolor="labeldisabled"
-		      bgcolor="none"
-		      font-family=basefont
-		      font-size=13
-		      font-weight=400
-		      font-style=regular
-		      inset="0 1 0 0"
+			textcolor="labeldisabled"
+			bgcolor="none"
+			font-family=basefont
+			font-size=13
+			font-weight=400
+			font-style=regular
+			inset="0 1 0 0"
 		}
-    
-    AccountBalanceStyle:Hover
+		
+		AccountBalanceStyle:Hover
 		{
-		      textcolor="texthover"
-		}  
+			textcolor="texthover"
+		}
 		
 		AccountBalanceSeparatorStyle
 		{
-					textcolor="ScrollGlyphDisabled"
-					font-family=basefont
-					font-size=13
-					font-weight=400
-		      font-style=regular
-					inset="0 0 0 0"
+			textcolor="ScrollGlyphDisabled"
+			font-family=basefont
+			font-size=13
+			font-weight=400
+			font-style=regular
+			inset="0 0 0 0"
 		}
 		
-		
-		new_label	
-		{			
+		new_label
+		{
 			bgcolor=none
 			render_bg={}
 			image="graphics/new_button"
@@ -200,7 +196,7 @@
 			image="graphics/new_button_hover"
 			inset="0 0 0 0"
 		}
-
+		
 		new_label_german
 		{
 			bgcolor=none
@@ -208,7 +204,7 @@
 			image="graphics/new_button_german"
 			inset="0 0 0 0"
 		}
-
+		
 		new_label_german:hover
 		{
 			bgcolor=none
@@ -216,7 +212,7 @@
 			image="graphics/new_button_hover_german"
 			inset="0 0 0 0"
 		}
-
+		
 		new_label_french
 		{
 			bgcolor=none
@@ -224,7 +220,7 @@
 			image="graphics/new_button_french"
 			inset="0 0 0 0"
 		}
-
+		
 		new_label_french:hover
 		{
 			bgcolor=none
@@ -240,7 +236,7 @@
 			image="graphics/new_button_italian"
 			inset="0 0 0 0"
 		}
-
+		
 		new_label_italian:hover
 		{
 			bgcolor=none
@@ -256,7 +252,7 @@
 			image="graphics/new_button_spanish"
 			inset="0 0 0 0"
 		}
-
+		
 		new_label_spanish:hover
 		{
 			bgcolor=none
@@ -272,7 +268,7 @@
 			image="graphics/new_button_danish"
 			inset="0 0 0 0"
 		}
-
+		
 		new_label_danish:hover
 		{
 			bgcolor=none
@@ -288,7 +284,7 @@
 			image="graphics/new_button_norwegian"
 			inset="0 0 0 0"
 		}
-
+		
 		new_label_norwegian:hover
 		{
 			bgcolor=none
@@ -304,7 +300,7 @@
 			image="graphics/new_button_swedish"
 			inset="0 0 0 0"
 		}
-
+		
 		new_label_swedish:hover
 		{
 			bgcolor=none
@@ -317,7 +313,7 @@
 		{
 			bgcolor="none"
 		}
-
+		
 		AddGameButton
 		{
 			font-size=14
@@ -340,32 +336,26 @@
 			{
 				0="image( x0 + 2, y0 + 7, x1, y1, graphics/icon_collapse_over )"
 			}
-		}	
+		}
 		
-
-
 		CSteamRootDialog
 		{
 			bgcolor=none
-
 			render_bg
 			{
 				// top area and graphic
-
+				
 				0="gradient( x0, y0, x1, y0+175, ClientBGTop, DialogBG )"
 				2="image( x0, y0, x1, y0+175, graphics/clienttexture2)"
-
-				3="fill( x0, y0+175, x0+20, y1-76, DialogBG )"			
-				4="fill( x1-20, y0+175, x1, y1-76, DialogBG )"			
-
+				
+				3="fill( x0, y0+175, x0+20, y1-76, DialogBG )"
+				4="fill( x1-20, y0+175, x1, y1-76, DialogBG )"
+				
 				// fill in the bottom area
 				5="fill( x0, y1 - 76, x1, y1, DialogBG )"
 			}
-		}		
-
-	
-
-
+		}
+		
 		FrameTitle
 		{
 			font-family=basefont
@@ -379,7 +369,7 @@
 				1="gradient( x0, y0, x1, y1 + 18, TitleBar, none )" [$OSX]
 			}
 		}
-				
+		
 		FrameTitle:framefocus
 		{
 			font-family=basefont
@@ -388,7 +378,6 @@
 			textcolor="Label"
 			bgcolor="none"
 			textcolor="Text"
-		
 			render_bg
 			{
 				1="gradient( x0, y0 - 4, x1, y1 + 18, titlebarfocus, none )"
@@ -398,29 +387,29 @@
 		
 		ClientTitle [!$OSX]
 		{
-			textcolor=none		
+			textcolor=none
 		}
-
+		
 		ClientTitle [$OSX]
 		{
 			font-family=basefont
 			font-size=15
-      		font-weight=400
-      		textcolor="textdisabled"
-      		bgcolor="none"
-      		inset="0 12 0 0"
+			font-weight=400
+			textcolor="textdisabled"
+			bgcolor="none"
+			inset="0 12 0 0"
 		}
-
+		
 		ClientTitle:FrameFocus [$OSX]
 		{
 			font-family=basefont
-   			font-size=15
-   			font-weight=400
-   			textcolor="texthover"
-   			bgcolor="none"
-   			inset="0 12 0 0"
+			font-size=15
+			font-weight=400
+			textcolor="texthover"
+			bgcolor="none"
+			inset="0 12 0 0"
 		}
-
+		
 		view_friends [!$OSX]
 		{
 			textcolor="LabelFocus"
@@ -433,7 +422,7 @@
 			padding-left=24
 			padding-bottom=30
 		}
-
+		
 		view_friends [$OSX]
 		{
 			textcolor="LabelFocus"
@@ -445,19 +434,18 @@
 			padding-top=6
 			padding-left=24
 			padding-bottom=30
-
 		}
-
+		
 		view_friends:Hover
 		{
-			 textcolor="white"
+			textcolor="white"
 		}
-
+		
 		view_friends:disabled
 		{
 			textcolor="TextDisabled"
 		}
-
+		
 		online_friends [!$OSX]
 		{
 			textcolor="label2"
@@ -466,7 +454,7 @@
 			font-size=14
 			font-style=regular
 		}
-
+		
 		online_friends [$OSX]
 		{
 			textcolor="label2"
@@ -475,12 +463,12 @@
 			font-size=13
 			font-style=regular
 		}
-
+		
 		online_friends:disabled
 		{
 			textcolor="TextDisabled"
 		}
-
+		
 		support_alert
 		{
 			font-family=basefont
@@ -493,9 +481,9 @@
 			padding-top=6
 			inset="-8 -3 8 0"
 			render {}
-			render_bg {
+			render_bg
+			{
 				0="fill( x0, y0 + 3, x1-1, y1, parental_lock_inactive1 )"
-
 			}
 		}
 		
@@ -511,11 +499,12 @@
 			padding-top=6
 			inset="-8 -3 8 0"
 			render {}
-			render_bg {
+			render_bg
+			{
 				0="fill( x0, y0 + 3, x1-1, y1, parental_lock_inactive3 )"
 			}
 		}
-
+		
 		support_alert_ack
 		{
 			font-family=basefont
@@ -528,12 +517,12 @@
 			padding-top=6
 			inset="-8 -3 8 0"
 			render {}
-			render_bg {
+			render_bg
+			{
 				0="fill( x0, y0 + 3, x1-1, y1, support_lock_ack1 )"
-
 			}
 		}
-
+		
 		support_alert_ack:hover
 		{
 			font-family=basefont
@@ -546,11 +535,12 @@
 			padding-top=6
 			inset="-8 -3 8 0"
 			render {}
-			render_bg {
+			render_bg
+			{
 				0="fill( x0, y0 + 3, x1-1, y1, support_lock_ack2 )"
 			}
 		}
-
+		
 		inbox_button [!$OSX]
 		{
 			font-family=basefont
@@ -566,7 +556,7 @@
 			render_bg
 			{
 				13="image( x1-22, y0+6, x1 -2, y1, graphics/inbox_notification_inactive )"
-			}	
+			}
 		}
 		
 		inbox_button [$OSX]
@@ -579,39 +569,34 @@
 			padding-left=0
 			padding-right=0
 			padding-top=6
-
 			inset="0 -2 8 0"
 			render {}
 			render_bg
 			{
 				13="image( x1-22, y0+6, x1 -2, y1, graphics/inbox_notification_inactive )"
-			}	
+			}
 		}
-
+		
 		inbox_button:hover
 		{
-
 			render {}
 			render_bg
 			{
-
 				1="image( x1-22, y0+6, x1 -2, y1, graphics/inbox_notification_inactive )"
-			}	
+			}
 		}
-
+		
 		inbox_button:selected
 		{
-
 			render {}
 			render_bg
 			{
 				// background fill
-				
 				0="gradient(  x0 -3, y0 + 3, x1+1, y1, almostblack, none )"
 				1="image( x1-22, y0+6, x1 -2, y1, graphics/inbox_notification_inactive )"
-			}	
+			}
 		}
-
+		
 		inbox_button:disabled
 		{
 		textcolor=labeldisabled
@@ -621,28 +606,27 @@
 			inset="0 -3 8 0" [!$OSX]
 			inset="0 -2 8 0" [$OSX]	
 			render {}
-					render_bg
+			render_bg
 			{
 				// background fill
 				1="image( x1-22, y0+5, x1 -2, y1, graphics/inbox_notification_inactive_disabled )"
-			}	
-		}	
-
+			}
+		}
+		
 		inbox_button_active
 		{
 			padding-left=3
 			padding-right=10
 			padding-top=6
 			inset="0 -3 8 0" [!$OSX]
-			inset="0 -2 8 0" [$OSX]		
+			inset="0 -2 8 0" [$OSX]
 			render {}
 			render_bg
 			{
 				// background fill
-				
-				0="fill(  x0 + 1, y0 + 3, x1+1, y1, green6 )"			
+				0="fill(  x0 + 1, y0 + 3, x1+1, y1, green6 )"
 				1="image( x1-22, y0+6, x1 -2, y1, graphics/inbox_notification )"
-			}	
+			}
 		}
 		
 		inbox_button_active:hover
@@ -653,13 +637,12 @@
 			inset="0 -3 8 0" [!$OSX]
 			inset="0 -2 8 0" [$OSX]	
 			render {}
-						render_bg
+			render_bg
 			{
 				// background fill
-				
-				0="fill(  x0 + 1, y0 + 3, x1+1, y1, green5 )"			
+				0="fill(  x0 + 1, y0 + 3, x1+1, y1, green5 )"
 				1="image( x1-22, y0+6, x1 -2, y1, graphics/inbox_notification )"
-			}	
+			}
 		}
 		inbox_button_active:selected
 		{
@@ -669,15 +652,14 @@
 			inset="0 -3 8 0" [!$OSX]
 			inset="0 -2 8 0" [$OSX]	
 			render {}
-						render_bg
+			render_bg
 			{
 				// background fill
-				
-				0="gradient(  x0 + 1, y0 + 3, x1+1, y1, green8, green7 )"		
+				0="gradient(  x0 + 1, y0 + 3, x1+1, y1, green8, green7 )"
 				1="image( x1-22, y0+6, x1 -2, y1, graphics/inbox_notification )"
-			}	
+			}
 		}
-
+		
 		inbox_button_active:disabled
 		{
 			padding-left=3
@@ -686,31 +668,31 @@
 			inset="0 -3 8 0" [!$OSX]
 			inset="0 -2 8 0" [$OSX]	
 			render {}
-						render_bg
+			render_bg
 			{
 				// background fill
 				1="image( x1-22, y0+6, x1 -2, y1, graphics/inbox_notification_disabled )"
-			}	
-		}	
+			}
+		}
 		
 		Menu
-    {
-		bgcolor="dialogbg"
-		padding-right=4
-		inset="2 2 2 2"
-      
-				render_bg
-				{
-					0="gradient( x0 + 1, y0 + 1, x1 - 1, y0+140, MenuBG1, MenuBG2  )"
-					1="fill( x0 + 1 , y0 + 140, x1 - 1, y1 - 1, MenuBG2  )"
-		
-					// lines around
+		{
+			bgcolor="dialogbg"
+			padding-right=4
+			inset="2 2 2 2"
+			render_bg
+			{
+				0="gradient( x0 + 1, y0 + 1, x1 - 1, y0+140, MenuBG1, MenuBG2  )"
+				1="fill( x0 + 1 , y0 + 140, x1 - 1, y1 - 1, MenuBG2  )"
+				
+				// lines around
 				2="fill( x0 + 1, y0, x1 - 1, y0 + 1, clientbg )"  // top
 				3="fill( x0 + 1, y1 - 1, x1 - 1, y1, clientbg )"  // bottom
 				4="fill( x0, y0 + 1, x0 + 1, y1 - 1, clientbg )"  // left
 				5="fill( x1 - 1, y0 + 1, x1, y1 - 1, clientbg )"  // right
-				}
+			}
 		}
+		
 		parental_lock_button
 		{
 			padding-left=3
@@ -722,24 +704,23 @@
 			{
 				// background fill
 				0="fill( x0 + 1, y0, x1 - 1, y1, parental_lock_inactive1 )"
-			}	
+			}
 		}
-
+		
 		parental_lock_button:hover
 		{
 			padding-left=3
 			padding-right=7
-		  padding-top=-1
+			padding-top=-1
 			image="resource/notfamilyview"
 			render {}
 			render_bg
 			{
 				// background fill
-				0="fill( x0 + 1, y0, x1 - 1, y1, parental_lock_inactive3 )"				
-			}	
-			
+				0="fill( x0 + 1, y0, x1 - 1, y1, parental_lock_inactive3 )"
+			}
 		}
-
+		
 		parental_lock_button:selected
 		{
 			padding-left=3
@@ -751,11 +732,9 @@
 			{
 				// background fill
 				0="fill( x0 + 1, y0, x1 - 1, y1, green6 )"
-			}	
-			
+			}
 		}
-
-
+		
 		parental_lock_button:selected:hover
 		{
 			padding-left=3
@@ -767,10 +746,9 @@
 			{
 				// background fill
 				0="fill( x0 + 1, y0, x1 - 1, y1, green5 )"
-			}	
-			
+			}
 		}
-
+		
 		FullscreenButton [!$OSX]
 		{
 			padding-left=0
@@ -778,7 +756,7 @@
 			padding-right=0
 			padding-bottom=0
 		}
-
+		
 		FullscreenButton [$OSX]
 		{
 			padding-left=0
@@ -794,7 +772,7 @@
 			padding-right=0
 			padding-bottom=0
 		}
-    
+		
 		VRButton [$OSX]
 		{
 			padding-left=0
@@ -810,7 +788,7 @@
 			padding-right=0
 			padding-bottom=0
 		}
-    
+		
 		VRButtonExit [$OSX]
 		{
 			padding-left=0
@@ -818,7 +796,7 @@
 			padding-right=0
 			padding-bottom=0
 		}
-    
+		
 		inboxmenuitem
 		{
 			textcolor=inbox_inactive_text
@@ -828,16 +806,16 @@
 		{
 			textcolor=label
 		}
-	
+		
 		inboxmenuitem_active:hover
 		{
 			textcolor=white
 		}
 		AccountURLStyle
 		{
-            image="skins/hidename/graphics/profile"
-            padding-top=-4
-            padding-right=-40
+			image="skins/hidename/graphics/profile"
+			padding-top=-4
+			padding-right=-40
 		}
 		
 		
@@ -849,9 +827,9 @@
 			inset="0 0 4 0"
 			image="graphics/osx_win_dis"[$OSX]
 		}
-    
-    FrameMinimizeButton:hover
-		{  
+		
+		FrameMinimizeButton:hover
+		{
 			render_bg {}
 			bgcolor="none"
 			inset="0 0 4 0"
@@ -865,15 +843,14 @@
 			inset="0 0 4 0"
 			image="graphics/osx_min_def"
 		}
-				
+		
 		FrameMinimizeButton:framefocus:hover [$OSX]
 		{
 			render_bg {}
 			inset="0 0 4 0"
 			image="graphics/osx_min_hov"
 		}
-
-
+		
 		// need the maximize button to have different styles for OSX & win32
 		FrameMaximizeButton
 		{
@@ -882,7 +859,7 @@
 			image="graphics/win32_win_max"
 			image="graphics/osx_win_dis" [$OSX]
 		}
-
+		
 		FrameMaximizeButton:hover
 		{
 			render_bg {}
@@ -891,7 +868,7 @@
 			image="graphics/win32_win_max_hover"
 			image="graphics/osx_max_hov" [$OSX]
 		}
-
+		
 		FrameMaximizeButton:framefocus
 		{
 			render_bg {}
@@ -900,7 +877,7 @@
 			image="graphics/win32_win_max"
 			image="graphics/osx_max_def" [$OSX]
 		}
-
+		
 		FrameMaximizeButton:framefocus:hover
 		{
 			render_bg {}
@@ -909,7 +886,7 @@
 			image="graphics/win32_win_max_hover"
 			image="graphics/osx_max_hov" [$OSX]
 		}
-
+		
 		FrameMaximizeButton:active
 		{
 			render_bg {}
@@ -918,7 +895,7 @@
 			image="graphics/win32_win_max_hover"
 			image="graphics/osx_max_down" [$OSX]
 		}
-
+		
 		// these are for when the maximize button becomes the restore button
 		FrameRestoreButton
 		{
@@ -927,7 +904,7 @@
 			image="graphics/win32_win_restore"
 			image="graphics/osx_win_dis" [$OSX]
 		}
-
+		
 		FrameRestoreButton:hover
 		{
 			render_bg {}
@@ -936,16 +913,16 @@
 			image="graphics/win32_win_restore_hover"
 			image="graphics/osx_max_hov" [$OSX]
 		}
-
+		
 		FrameRestoreButton:framefocus
 		{
 			render_bg {}
 			inset="0 0 4 0"
 			bgcolor="none"
 			image="graphics/win32_win_restore"
-	    		image="graphics/osx_max_def" [$OSX]
+			image="graphics/osx_max_def" [$OSX]
 		}
-
+		
 		FrameRestoreButton:framefocus:hover
 		{
 			render_bg {}
@@ -954,7 +931,7 @@
 			image="graphics/win32_win_restore_hover"
 			image="graphics/osx_max_hov" [$OSX]
 		}
-
+		
 		FrameRestoreButton:active
 		{
 			render_bg {}
@@ -963,7 +940,7 @@
 			image="graphics/win32_win_restore_hover"
 			image="graphics/osx_max_down" [$OSX]
 		}
-
+		
 		FrameCloseButton
 		{
 			render_bg {}
@@ -971,7 +948,7 @@
 			image="graphics/win32_win_close"
 			image="graphics/osx_win_dis" [$OSX]
 		}
-
+		
 		FrameCloseButton:hover
 		{
 			render_bg {}
@@ -979,22 +956,22 @@
 			image="graphics/win32_win_close_hover"
 			image="graphics/osx_close_hov" [$OSX]
 		}
-    
-    		FrameCloseButton:framefocus [$OSX]
+		
+		FrameCloseButton:framefocus [$OSX]
 		{
 			render_bg {}
 			inset="0 0 4 0"
 			bgcolor="none"
 			image="graphics/osx_close_def"
 		}
-
+		
 		FrameCloseButton:framefocus:hover [$OSX]
 		{
 			render_bg {}
 			bgcolor="none"
 			image="graphics/osx_close_hov"
 		}
-
+		
 		FrameCloseButton:active [$OSX]
 		{
 			render_bg {}
@@ -1002,8 +979,8 @@
 			bgcolor="none"
 			image="graphics/osx_close_down"
 		}
-    
-    FrameCloseButton:disabled
+		
+		FrameCloseButton:disabled
 		{
 			render_bg {}
 			inset="0 0 4 0"
@@ -1011,7 +988,6 @@
 			image="graphics/win32_win_close_disabled" 
 			image="graphics/osx_win_dis" [$OSX]
 		}
-				
 	}
 	
 	colors
@@ -1023,7 +999,7 @@
 		
 		inbox_active_text "text"
 		inbox_inactive_text "labeldisabled"
-
+		
 		backdrop "20 20 20 255"
 		
 		disabledborder "63 63 63 255"
@@ -1039,37 +1015,37 @@
 		place { control="UIStatusPanel" width=max height=40 align=bottom  margin-bottom=18 }
 		
 		place [!$OSX] { control="MenuBar" align=top margin-top=5 margin-left=2 }
-				
+		
 		place [!$OSX] { control="account_balance, account_balance_seperator, account_URL, universe_label, startvr, exitvr, fullscreen" align=right margin-top=12 margin-right=95 spacing=7 }
 		place [$OSX]  { control="account_balance, account_balance_seperator, account_URL, universe_label, startvr, exitvr, fullscreen" align=right margin-top=12 margin-right=15 spacing=7 }
-
-        place { control="account_URL" end-right="universe_label" align=right margin-top=9 width=25 }
-	
+		
+		place { control="account_URL" end-right="universe_label" align=right margin-top=9 width=25 }
+		
 		place [!$OSX] { control="fullscreen" align=right y=7 height=20 spacing=0 margin-right=85 margin-top=1 width=30 }
 		place [$OSX] { control="fullscreen" align=right y=7 height=20 spacing=0 margin-right=8 margin-top=1 width=30 }
 		
 		place [!$OSX] { control="startvr" end-right="fullscreen" align=right margin-right=6 margin-top=1 }
 		place [$OSX] { control="startvr" end-right="fullscreen" align=right margin-right=6 margin-top=1 }
-	
+		
 		place [!$OSX] { control="exitvr" end-right="fullscreen" align=right margin-right=6 margin-top=1 }
 		place [$OSX] { control="exitvr" end-right="fullscreen" align=right margin-right=6 margin-top=1 }
-
-  place { control="InboxButton" align=right end-right="account_balance" margin-top=4 margin-right=16 height=26 }
+		
+		place { control="InboxButton" align=right end-right="account_balance" margin-top=4 margin-right=16 height=26 }
 		place { control="ParentalLockButton" align=right end-right="InboxButton" margin-top=7 margin-right=10 height=23 }
 		place { control="SupportAlert" align=right end-right="ParentalLockButton" margin-top=4 margin-right=10 height=26 }
-
+		
 		place [!$OSX]  { control="frame_minimize,frame_maximize,frame_close" align=right margin-top=10 margin-right=9 spacing=-5 }
 		place [$OSX] { control="frame_close,frame_minimize,frame_maximize" align=left margin-top=10 margin-left=4 spacing=-7 }
-
+		
 		region { name=bottom align=bottom width=max height=75 }
 		
 		place { control="add_game" x=14 y=16 region=bottom height=30}
-
+		
 		place { control="FriendPanel" height=48 width=48 region=bottom align=right margin-right=2 margin-top=16 }
 		place { control="view_friends" height=62 y=12 region=bottom align=right dir=right margin-right=56 }
 		place { control="online_friends" height=12 y=38 region=bottom align=right dir=right margin-right=56 }
-	
- 		// the title bar is missing, so increase the size of the grip
+		
+		// the title bar is missing, so increase the size of the grip
 		place { control="frame_captiongrip" margin=2 width=max height=104 }
 	}
 }

--- a/hidename/resource/layout/steamrootdialog.layout
+++ b/hidename/resource/layout/steamrootdialog.layout
@@ -814,10 +814,9 @@
 		AccountURLStyle
 		{
 			image="skins/hidename/graphics/profile"
-			padding-top=-4
-			padding-right=-40
+			padding-top=-3
+			padding-right=-21
 		}
-		
 		
 		//unique styles for the client main window
 		FrameMinimizeButton


### PR DESCRIPTION
For users without a VR headset plugged in, the profile icon was overlapping the separator next to the Steam wallet amount.

I fixed the problem and made sure it was not breaking the layout when the VR icon is displayed.